### PR TITLE
Add an order edit page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,8 @@ import React from "react";
 import { Admin, Resource, EditGuesser } from "react-admin";
 import fakeDataProvider from "ra-data-fakerest";
 import generateData from "data-generator-retail";
-import { ProductList } from "./product/ProductList";
-import { CommandList } from "./command/CommandList";
-import { CommandEdit } from "./command/CommandEdit";
+import commands from "./command";
+import products from "./product";
 
 const dataProvider = fakeDataProvider(
   generateData({ serializeDate: true }),
@@ -14,17 +13,8 @@ const dataProvider = fakeDataProvider(
 function App() {
   return (
     <Admin dataProvider={dataProvider}>
-      <Resource
-        name="products"
-        options={{ label: "Posters" }}
-        list={ProductList}
-      />
-      <Resource
-        name="commands"
-        options={{ label: "Orders" }}
-        list={CommandList}
-        edit={CommandEdit}
-      />
+      <Resource name="products" {...products} />
+      <Resource name="commands" {...commands} />
     </Admin>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
 import React from "react";
-import { Admin, Resource, ListGuesser } from "react-admin";
+import { Admin, Resource, EditGuesser } from "react-admin";
 import fakeDataProvider from "ra-data-fakerest";
 import generateData from "data-generator-retail";
 import { ProductList } from "./product/ProductList";
 import { CommandList } from "./command/CommandList";
+import { CommandEdit } from "./command/CommandEdit";
 
 const dataProvider = fakeDataProvider(
   generateData({ serializeDate: true }),
@@ -13,8 +14,8 @@ const dataProvider = fakeDataProvider(
 function App() {
   return (
     <Admin dataProvider={dataProvider}>
-      <Resource name="posters" list={ProductList} />
-      <Resource name="orders" list={CommandList} />
+      <Resource name="products" list={ProductList} />
+      <Resource name="commands" list={CommandList} edit={CommandEdit} />
     </Admin>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,8 +14,17 @@ const dataProvider = fakeDataProvider(
 function App() {
   return (
     <Admin dataProvider={dataProvider}>
-      <Resource name="products" list={ProductList} />
-      <Resource name="commands" list={CommandList} edit={CommandEdit} />
+      <Resource
+        name="products"
+        options={{ label: "Posters" }}
+        list={ProductList}
+      />
+      <Resource
+        name="commands"
+        options={{ label: "Orders" }}
+        list={CommandList}
+        edit={CommandEdit}
+      />
     </Admin>
   );
 }

--- a/src/command/CommandEdit.tsx
+++ b/src/command/CommandEdit.tsx
@@ -31,12 +31,12 @@ import { Customer } from "../customer/customer";
 
 const CommandTitle = () => {
   const record = useRecordContext();
-  return <span>Command {record ? record.reference : ""}</span>;
+  return <span>Order {record ? record.reference : ""}</span>;
 };
 
-export const CommandEdit = () => (
-  <Edit resource="commands" title={<CommandTitle />}>
-    <SimpleForm>
+const CommandEditOrderFragment = () => {
+  return (
+    <>
       <Typography variant="h6">Order</Typography>
       <Labeled label="Date">
         <DateField source="date" />
@@ -53,7 +53,13 @@ export const CommandEdit = () => (
         ]}
       />
       <BooleanInput label="Returned" source="returned" />
+    </>
+  );
+};
 
+const CommandEditCustomerFragment = () => {
+  return (
+    <>
       <Typography variant="h6">Customer</Typography>
       <ReferenceField source="customer_id" reference="customers">
         <FunctionField
@@ -65,7 +71,13 @@ export const CommandEdit = () => (
       <ReferenceField source="customer_id" reference="customers">
         <EmailField source="email" />
       </ReferenceField>
+    </>
+  );
+};
 
+const CommandEditAddressFragment = () => {
+  return (
+    <>
       <Typography variant="h6">Shipping Address</Typography>
       <ReferenceField source="customer_id" reference="customers" link={false}>
         <Stack>
@@ -82,10 +94,23 @@ export const CommandEdit = () => (
           />
         </Stack>
       </ReferenceField>
+    </>
+  );
+};
 
+const CommandEditBasketFragment = () => {
+  return (
+    <>
       <Typography variant="h6">Items</Typography>
       <ArrayField source="basket">
-        <Datagrid>
+        <Datagrid
+          bulkActionButtons={false}
+          sx={{
+            "& .RaDatagrid-headerCell": { fontWeight: "bold" },
+            width: "100%",
+          }}
+          size="medium"
+        >
           <ReferenceField
             source="product_id"
             reference="products"
@@ -97,6 +122,7 @@ export const CommandEdit = () => (
             source="product_id"
             reference="products"
             label="Unit Price"
+            link={false}
           >
             <NumberField
               source="price"
@@ -107,7 +133,13 @@ export const CommandEdit = () => (
           {/* TODO - Total */}
         </Datagrid>
       </ArrayField>
+    </>
+  );
+};
 
+const CommandEditTotalsFragment = () => {
+  return (
+    <>
       <Typography variant="h6">Totals</Typography>
       <TableContainer>
         <Table>
@@ -162,6 +194,18 @@ export const CommandEdit = () => (
           </TableBody>
         </Table>
       </TableContainer>
+    </>
+  );
+};
+
+export const CommandEdit = () => (
+  <Edit resource="commands" title={<CommandTitle />}>
+    <SimpleForm>
+      <CommandEditOrderFragment />
+      <CommandEditCustomerFragment />
+      <CommandEditAddressFragment />
+      <CommandEditBasketFragment />
+      <CommandEditTotalsFragment />
     </SimpleForm>
   </Edit>
 );

--- a/src/command/CommandEdit.tsx
+++ b/src/command/CommandEdit.tsx
@@ -5,7 +5,6 @@ import {
   TableBody,
   TableCell,
   TableContainer,
-  TableFooter,
   TableRow,
   Typography,
 } from "@mui/material";
@@ -24,8 +23,6 @@ import {
   EmailField,
   ArrayField,
   NumberField,
-  FieldTitle,
-  DateInput,
   Labeled,
   RaRecord,
   WrapperField,

--- a/src/command/CommandEdit.tsx
+++ b/src/command/CommandEdit.tsx
@@ -1,4 +1,5 @@
 import {
+  Grid,
   Stack,
   Table,
   TableBody,
@@ -38,21 +39,31 @@ const CommandEditOrderFragment = () => {
   return (
     <>
       <Typography variant="h6">Order</Typography>
-      <Labeled label="Date">
-        <DateField source="date" />
-      </Labeled>
-      <Labeled label="Reference">
-        <TextField source="reference" />
-      </Labeled>
-      <SelectInput
-        source="status"
-        choices={[
-          { id: "delivered", name: "delivered" },
-          { id: "ordered", name: "ordered" },
-          { id: "cancelled", name: "cancelled" },
-        ]}
-      />
-      <BooleanInput label="Returned" source="returned" />
+      <Grid container spacing={2} alignItems="center">
+        <Grid item xs={6}>
+          <Labeled label="Date">
+            <DateField source="date" />
+          </Labeled>
+        </Grid>
+        <Grid item xs={6}>
+          <Labeled label="Reference">
+            <TextField source="reference" />
+          </Labeled>
+        </Grid>
+        <Grid item xs={6}>
+          <SelectInput
+            source="status"
+            choices={[
+              { id: "delivered", name: "delivered" },
+              { id: "ordered", name: "ordered" },
+              { id: "cancelled", name: "cancelled" },
+            ]}
+          />
+        </Grid>
+        <Grid item xs={6}>
+          <BooleanInput label="Returned" source="returned" />
+        </Grid>
+      </Grid>
     </>
   );
 };
@@ -61,16 +72,18 @@ const CommandEditCustomerFragment = () => {
   return (
     <>
       <Typography variant="h6">Customer</Typography>
-      <ReferenceField source="customer_id" reference="customers">
-        <FunctionField
-          render={(customer: Customer) =>
-            `${customer.first_name} ${customer.last_name}`
-          }
-        />
-      </ReferenceField>
-      <ReferenceField source="customer_id" reference="customers">
-        <EmailField source="email" />
-      </ReferenceField>
+      <Stack>
+        <ReferenceField source="customer_id" reference="customers">
+          <FunctionField
+            render={(customer: Customer) =>
+              `${customer.first_name} ${customer.last_name}`
+            }
+          />
+        </ReferenceField>
+        <ReferenceField source="customer_id" reference="customers">
+          <EmailField source="email" />
+        </ReferenceField>
+      </Stack>
     </>
   );
 };
@@ -201,11 +214,25 @@ const CommandEditTotalsFragment = () => {
 export const CommandEdit = () => (
   <Edit resource="commands" title={<CommandTitle />}>
     <SimpleForm>
-      <CommandEditOrderFragment />
-      <CommandEditCustomerFragment />
-      <CommandEditAddressFragment />
-      <CommandEditBasketFragment />
-      <CommandEditTotalsFragment />
+      <Grid container spacing={2}>
+        <Grid item xs={8}>
+          <CommandEditOrderFragment />
+        </Grid>
+        <Grid item container xs={4} spacing={2} direction="column">
+          <Grid item>
+            <CommandEditCustomerFragment />
+          </Grid>
+          <Grid item>
+            <CommandEditAddressFragment />
+          </Grid>
+        </Grid>
+        <Grid item xs={12}>
+          <CommandEditBasketFragment />
+        </Grid>
+        <Grid item xs={12}>
+          <CommandEditTotalsFragment />
+        </Grid>
+      </Grid>
     </SimpleForm>
   </Edit>
 );

--- a/src/command/CommandEdit.tsx
+++ b/src/command/CommandEdit.tsx
@@ -1,0 +1,167 @@
+import {
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableFooter,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import * as React from "react";
+import {
+  Datagrid,
+  TextField,
+  ReferenceField,
+  Edit,
+  SimpleForm,
+  SelectInput,
+  useRecordContext,
+  DateField,
+  BooleanInput,
+  FunctionField,
+  EmailField,
+  ArrayField,
+  NumberField,
+  FieldTitle,
+  DateInput,
+  Labeled,
+} from "react-admin";
+import { Customer } from "../customer/customer";
+
+const CommandTitle = () => {
+  const record = useRecordContext();
+  return <span>Command {record ? record.reference : ""}</span>;
+};
+
+export const CommandEdit = () => (
+  <Edit resource="commands" title={<CommandTitle />}>
+    <SimpleForm>
+      <Typography variant="h6">Order</Typography>
+      <Labeled label="Date">
+        <DateField source="date" />
+      </Labeled>
+      <Labeled label="Reference">
+        <TextField source="reference" />
+      </Labeled>
+      <SelectInput
+        source="status"
+        choices={[
+          { id: "delivered", name: "delivered" },
+          { id: "ordered", name: "ordered" },
+          { id: "cancelled", name: "cancelled" },
+        ]}
+      />
+      <BooleanInput label="Returned" source="returned" />
+
+      <Typography variant="h6">Customer</Typography>
+      <ReferenceField source="customer_id" reference="customers">
+        <FunctionField
+          render={(customer: Customer) =>
+            `${customer.first_name} ${customer.last_name}`
+          }
+        />
+      </ReferenceField>
+      <ReferenceField source="customer_id" reference="customers">
+        <EmailField source="email" />
+      </ReferenceField>
+
+      <Typography variant="h6">Shipping Address</Typography>
+      <ReferenceField source="customer_id" reference="customers" link={false}>
+        <Stack>
+          <FunctionField
+            render={(customer: Customer) =>
+              `${customer.first_name} ${customer.last_name}`
+            }
+          />
+          <TextField source="address" />
+          <FunctionField
+            render={(customer: Customer) =>
+              [customer.city, customer.zipcode].join(", ")
+            }
+          />
+        </Stack>
+      </ReferenceField>
+
+      <Typography variant="h6">Items</Typography>
+      <ArrayField source="basket">
+        <Datagrid>
+          <ReferenceField
+            source="product_id"
+            reference="products"
+            label="Reference"
+          >
+            <TextField source="reference" />
+          </ReferenceField>
+          <ReferenceField
+            source="product_id"
+            reference="products"
+            label="Unit Price"
+          >
+            <NumberField
+              source="price"
+              options={{ style: "currency", currency: "USD" }}
+            />
+          </ReferenceField>
+          <NumberField label="Quantity" source="quantity" />
+          {/* TODO - Total */}
+        </Datagrid>
+      </ArrayField>
+
+      <Typography variant="h6">Totals</Typography>
+      <TableContainer>
+        <Table>
+          <TableBody>
+            <TableRow key="total_ex_taxes">
+              <TableCell component="th" scope="row">
+                Sum
+              </TableCell>
+              <TableCell align="right">
+                <NumberField
+                  source="total_ex_taxes"
+                  options={{ style: "currency", currency: "USD" }}
+                />
+              </TableCell>
+            </TableRow>
+            <TableRow key="delivery_fees">
+              <TableCell component="th" scope="row">
+                Delivery
+              </TableCell>
+              <TableCell align="right">
+                <NumberField
+                  source="delivery_fees"
+                  options={{ style: "currency", currency: "USD" }}
+                />
+              </TableCell>
+            </TableRow>
+            <TableRow key="taxes">
+              <TableCell component="th" scope="row">
+                <FunctionField
+                  render={(order: { tax_rate: any }) =>
+                    `Tax (${order.tax_rate * 100} %)`
+                  }
+                />
+              </TableCell>
+              <TableCell align="right">
+                <NumberField
+                  source="taxes"
+                  options={{ style: "currency", currency: "USD" }}
+                />
+              </TableCell>
+            </TableRow>
+            <TableRow key="total">
+              <TableCell sx={{ fontWeight: "bold" }}>Total</TableCell>
+              <TableCell align="right" sx={{ fontWeight: "bold" }}>
+                <NumberField
+                  source="total"
+                  options={{ style: "currency", currency: "USD" }}
+                  sx={{ fontWeight: "bold" }}
+                />
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </SimpleForm>
+  </Edit>
+);

--- a/src/command/CommandEdit.tsx
+++ b/src/command/CommandEdit.tsx
@@ -27,7 +27,10 @@ import {
   FieldTitle,
   DateInput,
   Labeled,
+  RaRecord,
+  WrapperField,
 } from "react-admin";
+import { NumberFunctionField } from "../common/NumberFunctionField";
 import { Customer } from "../customer/customer";
 
 const CommandTitle = () => {
@@ -111,6 +114,19 @@ const CommandEditAddressFragment = () => {
   );
 };
 
+const CommandEditBasketItemTotalFragment = () => {
+  const basketItem = useRecordContext();
+  if (!basketItem) return null;
+  return (
+    <ReferenceField source="product_id" reference="products" link={false}>
+      <NumberFunctionField
+        render={(record: RaRecord) => record.price * basketItem.quantity}
+        options={{ style: "currency", currency: "USD" }}
+      />
+    </ReferenceField>
+  );
+};
+
 const CommandEditBasketFragment = () => {
   return (
     <>
@@ -143,7 +159,9 @@ const CommandEditBasketFragment = () => {
             />
           </ReferenceField>
           <NumberField label="Quantity" source="quantity" />
-          {/* TODO - Total */}
+          <WrapperField label="Total" textAlign="right">
+            <CommandEditBasketItemTotalFragment />
+          </WrapperField>
         </Datagrid>
       </ArrayField>
     </>

--- a/src/command/CommandList.tsx
+++ b/src/command/CommandList.tsx
@@ -89,7 +89,7 @@ const TabbedCommandList = () => {
 
 export const CommandList = () => {
   return (
-    <List resource="commands" title="Orders" filters={filters}>
+    <List title="Orders" filters={filters}>
       <TabbedCommandList />
     </List>
   );

--- a/src/command/index.ts
+++ b/src/command/index.ts
@@ -1,0 +1,8 @@
+import { CommandEdit } from "./CommandEdit";
+import { CommandList } from "./CommandList";
+
+export default {
+  list: CommandList,
+  edit: CommandEdit,
+  options: { label: "Orders" },
+};

--- a/src/common/NumberFunctionField.tsx
+++ b/src/common/NumberFunctionField.tsx
@@ -1,0 +1,19 @@
+import { NumberField, RaRecord, useRecordContext } from "react-admin";
+
+export const NumberFunctionField = (props: {
+  render: (record: RaRecord) => number;
+  options: {
+    style: string;
+    currency: string;
+  };
+}) => {
+  const record = useRecordContext();
+  if (!record) return null;
+  return (
+    <NumberField
+      options={props.options}
+      record={{ data: props.render(record) }}
+      source="data"
+    />
+  );
+};

--- a/src/product/ProductList.tsx
+++ b/src/product/ProductList.tsx
@@ -7,7 +7,7 @@ import {
 } from "react-admin";
 
 export const ProductList = () => (
-  <List resource="products" title="Posters">
+  <List title="Posters">
     <Datagrid rowClick="edit">
       <TextField source="id" />
       <ReferenceField source="category_id" reference="categories">

--- a/src/product/index.ts
+++ b/src/product/index.ts
@@ -1,0 +1,6 @@
+import { ProductList } from "./ProductList";
+
+export default {
+  list: ProductList,
+  options: { label: "Posters" },
+};


### PR DESCRIPTION
## Content
- [x] Add an order edit page, handling relations, and displayed nicely thanks to a grid layout
- [x] Compute the total amount by item in the 'Items' fragment

## Demo
![2022-03-22 15_37_27-Vite App](https://user-images.githubusercontent.com/14542336/159507194-e69d1c18-13a5-48d1-8e3f-21f2472740c5.png)

