### PR TITLE
Improve poster list: display thumbnails in data grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,8 @@ import generateData from "data-generator-retail";
 import { ProductList } from "./product/ProductList";
 import { CommandList } from "./command/CommandList";
 import { CommandEdit } from "./command/CommandEdit";
+import MonetizationOnIcon from "@mui/icons-material/MonetizationOn";
+import PhotoSizeSelectActualIcon from "@mui/icons-material/PhotoSizeSelectActual";
 
 const dataProvider = fakeDataProvider(
   generateData({ serializeDate: true }),
@@ -18,12 +20,14 @@ function App() {
         name="products"
         options={{ label: "Posters" }}
         list={ProductList}
+        icon={PhotoSizeSelectActualIcon}
       />
       <Resource
         name="commands"
         options={{ label: "Orders" }}
         list={CommandList}
         edit={CommandEdit}
+        icon={MonetizationOnIcon}
       />
     </Admin>
   );

--- a/src/command/index.ts
+++ b/src/command/index.ts
@@ -1,8 +1,10 @@
 import { CommandEdit } from "./CommandEdit";
 import { CommandList } from "./CommandList";
+import MonetizationOnIcon from "@mui/icons-material/MonetizationOn";
 
 export default {
   list: CommandList,
   edit: CommandEdit,
   options: { label: "Orders" },
+  icon: MonetizationOnIcon,
 };

--- a/src/product/ProductList.tsx
+++ b/src/product/ProductList.tsx
@@ -1,23 +1,70 @@
+import { ImageList, ImageListItem, ImageListItemBar } from "@mui/material";
 import {
+  FunctionField,
   List,
-  Datagrid,
-  TextField,
-  ReferenceField,
   NumberField,
+  useListContext,
+  WrapperField,
 } from "react-admin";
+
+export const PosterDataGrid = () => {
+  const { data } = useListContext();
+
+  if (!data) return null;
+
+  return (
+    <ImageList
+      sx={{
+        // Promote the list into its own layer in Chrome. This costs memory, but helps keeping high FPS.
+        transform: "translateZ(0)",
+        margin: 0,
+      }}
+      rowHeight={180}
+      gap={1}
+      cols={3} // TODO: see if I can make this responsive...
+    >
+      {data.map((product) => {
+        return (
+          <ImageListItem key={product.id}>
+            <img
+              src={product.thumbnail}
+              alt={product.reference}
+              loading="lazy"
+              style={{ width: "100%", height: "100%", objectFit: "cover" }}
+            />
+            <ImageListItemBar
+              sx={{
+                background:
+                  "linear-gradient(to top, rgba(0,0,0,0.9) 0%, " +
+                  "rgba(0,0,0,0.4) 70%, rgba(0,0,0,0) 100%)",
+              }}
+              title={product.reference}
+              subtitle={
+                <WrapperField>
+                  <FunctionField
+                    record={product}
+                    render={(record: any) =>
+                      `${record.width}x${record.height}, `
+                    }
+                  />
+                  <NumberField
+                    record={product}
+                    source="price"
+                    options={{ style: "currency", currency: "USD" }}
+                  />
+                </WrapperField>
+              }
+              position="bottom"
+            />
+          </ImageListItem>
+        );
+      })}
+    </ImageList>
+  );
+};
 
 export const ProductList = () => (
   <List title="Posters">
-    <Datagrid rowClick="edit">
-      <TextField source="id" />
-      <ReferenceField source="category_id" reference="categories">
-        <TextField source="id" />
-      </ReferenceField>
-      <NumberField source="width" />
-      <NumberField source="height" />
-      <NumberField source="price" />
-      <TextField source="thumbnail" />
-      <TextField source="image" />
-    </Datagrid>
+    <PosterDataGrid />
   </List>
 );

--- a/src/product/index.ts
+++ b/src/product/index.ts
@@ -1,6 +1,8 @@
 import { ProductList } from "./ProductList";
+import PhotoSizeSelectActualIcon from "@mui/icons-material/PhotoSizeSelectActual";
 
 export default {
   list: ProductList,
   options: { label: "Posters" },
+  icon: PhotoSizeSelectActualIcon,
 };


### PR DESCRIPTION
## Content

- [x] Use MUI's ImageList to display posters as an image list
- [x] Add icons to resource menu so that it's easier to see what's what

To be done later: make ImageList responsive

## Demo
![2022-03-22 18_14_24-ProductList tsx - admin-e-commerce-demo  WSL_ Ubuntu-20 04  - Visual Studio Code](https://user-images.githubusercontent.com/14542336/159537938-272ee9a6-4452-481a-ad30-f9cb18ef16dd.png)

